### PR TITLE
removed the FAIL_ON_UNKNOWN_PROPERTIES feature for JacksonSchemaGener…

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server</groupId>
     <artifactId>kotlin-uapi-core-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Core Parent POM</name>
@@ -22,7 +22,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-core-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencies>
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server</groupId>
             <artifactId>uapi-schemagen</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
         <dependency>
             <groupId>edu.byu.uapi.model</groupId>

--- a/core/schemagen/pom.xml
+++ b/core/schemagen/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-core-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencies>

--- a/core/schemagen/src/main/kotlin/JacksonSchemaGenerator.kt
+++ b/core/schemagen/src/main/kotlin/JacksonSchemaGenerator.kt
@@ -1,9 +1,6 @@
 package edu.byu.uapi.schemagen
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.PropertyNamingStrategy
-import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.databind.*
 import com.fasterxml.jackson.module.kotlin.treeToValue
 import com.kjetland.jackson.jsonSchema.JsonSchemaGenerator
 import edu.byu.uapi.model.jsonschema07.Schema
@@ -16,6 +13,7 @@ private val defaultObjectMapper by lazy { ObjectMapper().apply {
     registerModule(UAPIModelModule())
     disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
     propertyNamingStrategy = PropertyNamingStrategy.SNAKE_CASE
+    disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
 } }
 
 class JacksonSchemaGenerator(mapper: ObjectMapper = defaultObjectMapper): SchemaGenerator {

--- a/core/spi/pom.xml
+++ b/core/spi/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-core-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/core/utility-types/pom.xml
+++ b/core/utility-types/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-core-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/core/validation/hibernate-validator/pom.xml
+++ b/core/validation/hibernate-validator/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.validation</groupId>
         <artifactId>kotlin-uapi-validation-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencies>

--- a/core/validation/pom.xml
+++ b/core/validation/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server.validation</groupId>
     <artifactId>kotlin-uapi-validation-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Validation Parent POM</name>
@@ -18,7 +18,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-core-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>

--- a/examples/lambda-hello-world/pom.xml
+++ b/examples/lambda-hello-world/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>kotlin-uapi-examples-pom</artifactId>
         <groupId>edu.byu.uapi.server.examples</groupId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/examples/library/common/pom.xml
+++ b/examples/library/common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>kotlin-uapi-library-example-pom</artifactId>
         <groupId>edu.byu.uapi.server.examples</groupId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/library/interface-style/pom.xml
+++ b/examples/library/interface-style/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>kotlin-uapi-library-example-pom</artifactId>
         <groupId>edu.byu.uapi.server.examples</groupId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/examples/library/pom.xml
+++ b/examples/library/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kotlin-uapi-library-example-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Examples - Library - Parent POM</name>
@@ -18,7 +18,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.examples</groupId>
         <artifactId>kotlin-uapi-examples-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>

--- a/examples/library/tutorial-steps/1-initial-setup/pom.xml
+++ b/examples/library/tutorial-steps/1-initial-setup/pom.xml
@@ -20,7 +20,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/2-main-class/pom.xml
+++ b/examples/library/tutorial-steps/2-main-class/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/3-user-context/pom.xml
+++ b/examples/library/tutorial-steps/3-user-context/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/4-creating-a-resource/pom.xml
+++ b/examples/library/tutorial-steps/4-creating-a-resource/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/5-response-body/pom.xml
+++ b/examples/library/tutorial-steps/5-response-body/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/6-listing-resources/pom.xml
+++ b/examples/library/tutorial-steps/6-listing-resources/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/library/tutorial-steps/7-mutating-resources/pom.xml
+++ b/examples/library/tutorial-steps/7-mutating-resources/pom.xml
@@ -19,7 +19,7 @@
             <dependency>
                 <groupId>edu.byu.uapi.server</groupId>
                 <artifactId>uapi-bom</artifactId>
-                <version>0.5.5-SNAPSHOT</version>
+                <version>0.5.5</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>edu.byu.uapi.server.examples</groupId>
             <artifactId>library-example-common</artifactId>
-            <version>0.5.5-SNAPSHOT</version>
+            <version>0.5.5</version>
         </dependency>
 
         <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server.examples</groupId>
     <artifactId>kotlin-uapi-examples-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Examples - Parent POM</name>
@@ -19,7 +19,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>

--- a/http/aws-lambda-proxy/pom.xml
+++ b/http/aws-lambda-proxy/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.http</groupId>
         <artifactId>kotlin-uapi-http-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/http/common/pom.xml
+++ b/http/common/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.http</groupId>
         <artifactId>kotlin-uapi-http-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server.http</groupId>
     <artifactId>kotlin-uapi-http-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI HTTP Bindings Parent POM</name>
@@ -20,7 +20,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>

--- a/http/spark/pom.xml
+++ b/http/spark/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.http</groupId>
         <artifactId>kotlin-uapi-http-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server</groupId>
     <artifactId>kotlin-uapi-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Parent POM</name>

--- a/utilities/jwt-extensions/pom.xml
+++ b/utilities/jwt-extensions/pom.xml
@@ -13,7 +13,7 @@
     <parent>
         <groupId>edu.byu.uapi.server.utilities</groupId>
         <artifactId>kotlin-uapi-utilities-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <properties>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>edu.byu.uapi.server.utilities</groupId>
     <artifactId>kotlin-uapi-utilities-pom</artifactId>
-    <version>0.5.5-SNAPSHOT</version>
+    <version>0.5.5</version>
     <packaging>pom</packaging>
 
     <name>Kotlin UAPI Utilities Parent POM</name>
@@ -18,7 +18,7 @@
     <parent>
         <groupId>edu.byu.uapi.server</groupId>
         <artifactId>kotlin-uapi-pom</artifactId>
-        <version>0.5.5-SNAPSHOT</version>
+        <version>0.5.5</version>
     </parent>
 
     <dependencyManagement>


### PR DESCRIPTION
…ator

It was failing because it didn't know what to do with the `definitions` section that was no longer needed after inserting the objects directly.